### PR TITLE
edit functionality of the "find" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   * to export the case list to an external database
 
 * Example commands:
-  * ...
+  * find n/<name>: finds a case by the name
+  * add p/<Postal code> n/: adds 
 
 * The project is built on an ongoing software project for a desktop application (called _AddressBook_) used for managing contact details, named `AddressBook Level 3` (`AB3` for short).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
   * to export the case list to an external database
 
 * Example commands:
-  * find n/<name>: finds a case by the name
-  * add p/<Postal code> n/: adds 
+  * find <keyword>: finds a case profile by provided keyword, and displays cases whose names contain the keyword
+  * add ...
+  * delete ...
 
 * The project is built on an ongoing software project for a desktop application (called _AddressBook_) used for managing contact details, named `AddressBook Level 3` (`AB3` for short).

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -173,7 +173,7 @@ public class MainApp extends Application {
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping Program ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * Helper functions for handling strings.
@@ -36,6 +37,27 @@ public class StringUtil {
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code substring}.
+     * Ignores case, and a full word match is not required.
+     * @param sentence cannot be null
+     * @param substring cannot be null
+     */
+    public static boolean containsSubstringIgnoreCase(String sentence, String substring) {
+        Pattern pattern = Pattern.compile(substring, Pattern.CASE_INSENSITIVE);
+        requireNonNull(sentence);
+        requireNonNull(substring);
+        String preppedString = substring.trim();
+
+        checkArgument(!preppedString.isEmpty(), "String parameter cannot be empty");
+        checkArgument(preppedString.split("\\s+").length == 1, "String parameter should be a single character");
+
+
+        String[] wordsInPreppedSentence = sentence.split("\\s+");
+
+    return Arrays.stream(wordsInPreppedSentence).anyMatch(w -> pattern.matcher(w).find());
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -54,10 +54,13 @@ public class StringUtil {
         checkArgument(!preppedString.isEmpty(), "String parameter cannot be empty");
         checkArgument(preppedString.split("\\s+").length == 1, "String parameter should be a single character");
 
-
         String[] wordsInPreppedSentence = sentence.split("\\s+");
 
     return Arrays.stream(wordsInPreppedSentence).anyMatch(w -> pattern.matcher(w).find());
+    }
+
+    public static boolean startsWithSubstringIgnoreCase(String sentence, String substring) {
+        return containsSubstringIgnoreCase(sentence, String.format("^%s", substring));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -17,8 +17,11 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        Predicate<String> containsName = keyword -> StringUtil.containsSubstringIgnoreCase(person.getName().fullName, keyword);
+        Predicate<String> containsPostal = keynum -> StringUtil.startsWithSubstringIgnoreCase(person.getPostal().value, keynum);
+        Predicate<String> containsPostalOrName = containsPostal.or(containsName);
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(containsPostalOrName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -19,7 +19,7 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Postal("87438807"), new Email("alexyeoh@example.com"),
+            new Person(new Name("Alex Yeoh"), new Postal("674388"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Postal("992727"), new Email("berniceyu@example.com"),


### PR DESCRIPTION
Functionality of the "find" command seems to be limited in that only whole-word searches are accepted.

A new function within StringUtil is added to accommodate searches that are not whole-words.

This allows for easier searching, especially for users who may not remember the whole word. For example, "Bern" in "Bernice".