### PR TITLE
Change how the GUI displays case details

### DIFF
--- a/src/main/java/seedu/dengue/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/dengue/model/util/SampleDataUtil.java
@@ -23,7 +23,7 @@ public class SampleDataUtil {
                 new Age("111"),
                 getTagSet("DENV1")),
             new Person(new Name("Bernice Yu"), new Postal("992727"), new Date("2000-11-11"),
-                new Age("DENV2"),
+                new Age("11"),
                 getTagSet("DENV2", "DENV4")),
             new Person(new Name("Charlotte Oliveiro"), new Postal("932283"),
                     new Date("2000-11-11"), new Age("0"),

--- a/src/main/java/seedu/dengue/ui/PersonCard.java
+++ b/src/main/java/seedu/dengue/ui/PersonCard.java
@@ -34,7 +34,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label phone;
+    private Label postal;
     @FXML
     private Label age;
     @FXML
@@ -50,9 +50,9 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        phone.setText(person.getPostal().value);
-        age.setText(person.getAge().value);
-        date.setText(person.getDate().value);
+        postal.setText("Postal Code: " + person.getPostal().value);
+        age.setText("Age: " + person.getAge().value + " years");
+        date.setText("Case reported on " + person.getDate().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName.toString())));

--- a/src/main/java/seedu/dengue/ui/PersonCard.java
+++ b/src/main/java/seedu/dengue/ui/PersonCard.java
@@ -1,7 +1,6 @@
 package seedu.dengue.ui;
 
 import java.util.Comparator;
-import java.util.Objects;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;

--- a/src/main/java/seedu/dengue/ui/PersonCard.java
+++ b/src/main/java/seedu/dengue/ui/PersonCard.java
@@ -1,6 +1,7 @@
 package seedu.dengue.ui;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -15,6 +16,9 @@ import seedu.dengue.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
+    private static final String AGE_FORMAT = "%s y/o";
+    private static final String POSTAL_FORMAT = "Postal Code: %s";
+    private static final String DATE_FORMAT = "Case reported on %s";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -34,9 +38,9 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label postal;
-    @FXML
     private Label age;
+    @FXML
+    private Label postal;
     @FXML
     private Label date;
     @FXML
@@ -50,9 +54,9 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        postal.setText("Postal Code: " + person.getPostal().value);
-        age.setText("Age: " + person.getAge().value + " years");
-        date.setText("Case reported on " + person.getDate().value);
+        age.setText(String.format(AGE_FORMAT, person.getAge().value));
+        postal.setText(String.format(POSTAL_FORMAT, person.getPostal().value));
+        date.setText(String.format(DATE_FORMAT, person.getDate().value));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName.toString())));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -121,14 +121,20 @@
 }
 
 .cell_big_label {
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: "Verdana";
     -fx-font-size: 16px;
     -fx-text-fill: #010504;
 }
 
+.age_label {
+    -fx-font-family: "Lucida Sans Typewriter";
+    -fx-font-size: 12px;
+    -fx-font-style: italic;
+    -fx-text-fill: #010504;
+}
 .cell_small_label {
-    -fx-font-family: "Segoe UI";
-    -fx-font-size: 13px;
+    -fx-font-family: "Lucida Sans Typewriter";
+    -fx-font-size: 12px;
     -fx-text-fill: #010504;
 }
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,8 +28,8 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="postal" styleClass="cell_small_label" text="\$postal" />
       <Label fx:id="age" styleClass="cell_small_label" text="\$age" />
+      <Label fx:id="postal" styleClass="cell_small_label" text="\$postal" />
       <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
     </VBox>
   </GridPane>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,7 +28,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="postal" styleClass="cell_small_label" text="\$postal" />
       <Label fx:id="age" styleClass="cell_small_label" text="\$age" />
       <Label fx:id="date" styleClass="cell_small_label" text="\$date" />
     </VBox>


### PR DESCRIPTION
The current vestigial GUI does not suit DHT.

Modifying the format, font and text for case details may help with readability and understandability.

Let's change the GUI to display the details of each case in a better way.