### PR TITLE
Update clear command functionality

### DIFF
--- a/src/main/java/seedu/dengue/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/dengue/logic/commands/ClearCommand.java
@@ -2,22 +2,29 @@ package seedu.dengue.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.dengue.model.DengueHotspotTracker;
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.dengue.model.Model;
+import seedu.dengue.model.person.Person;
 
 /**
- * Clears the Dengue Hotspot Tracker.
+ * Clears all persons in the current displayed list of the Dengue Hotspot Tracker.
  */
 public class ClearCommand extends Command {
-
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Dengue Hotspot Tracker has been cleared!";
+    public static final String MESSAGE_SUCCESS = "%1$s persons cleared!";
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setDengueHotspotTracker(new DengueHotspotTracker());
-        return new CommandResult(MESSAGE_SUCCESS);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> referenceCopy = new ArrayList<>(lastShownList);
+        int listSize = lastShownList.size();
+        for (Person person : referenceCopy) {
+            model.deletePerson(person);
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, listSize));
     }
 }

--- a/src/test/java/seedu/dengue/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/dengue/logic/commands/ClearCommandTest.java
@@ -1,7 +1,12 @@
 package seedu.dengue.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.dengue.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.dengue.testutil.TypicalPersons.getTypicalDengueHotspotTracker;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,24 +14,71 @@ import seedu.dengue.model.DengueHotspotTracker;
 import seedu.dengue.model.Model;
 import seedu.dengue.model.ModelManager;
 import seedu.dengue.model.UserPrefs;
+import seedu.dengue.model.person.Person;
+import seedu.dengue.model.person.PersonContainsKeywordsPredicate;
 
 public class ClearCommandTest {
-
     @Test
     public void execute_emptyDengueHotspotTracker_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> referenceCopy = new ArrayList<>(lastShownList);
+
+        String expectedMessage = String.format(ClearCommand.MESSAGE_SUCCESS, referenceCopy.size());
+        assertCommandSuccess(new ClearCommand(), model, expectedMessage, expectedModel);
     }
 
+
     @Test
-    public void execute_nonEmptyDengueHotspotTracker_success() {
+    public void execute_unfilteredNonEmptyDengueHotspotTracker_success() {
         Model model = new ModelManager(getTypicalDengueHotspotTracker(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalDengueHotspotTracker(), new UserPrefs());
         expectedModel.setDengueHotspotTracker(new DengueHotspotTracker());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> referenceCopy = new ArrayList<>(lastShownList);
+
+        String expectedMessage = String.format(ClearCommand.MESSAGE_SUCCESS, referenceCopy.size());
+        assertCommandSuccess(new ClearCommand(), model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_filteredNonEmptyDengueHotspotTracker_success() {
+        Model model = new ModelManager(getTypicalDengueHotspotTracker(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalDengueHotspotTracker(), new UserPrefs());
+
+        PersonContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        model.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> referenceCopy = new ArrayList<>(lastShownList);
+        for (Person person : referenceCopy) {
+            expectedModel.deletePerson(person);
+        }
+        showNoPerson(expectedModel);
+
+        String expectedMessage = String.format(ClearCommand.MESSAGE_SUCCESS, referenceCopy.size());
+        assertCommandSuccess(new ClearCommand(), model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assertTrue(model.getFilteredPersonList().isEmpty());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private PersonContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new PersonContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
 }


### PR DESCRIPTION
The clear command clears the entire Dengue Hotspot Tracker.

This functionality is unlikely to be regularly used. We could expand its functionality to clear only the currently shown list. The current functionality can be preserved by listing the entire list, then clearing it.

Let's update the clear command functionality and corresponding tests.

Closes #84