### PR TITLE
Fix bug with checking for index after date

### DIFF
--- a/src/main/java/seedu/dengue/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/dengue/logic/commands/DeleteCommand.java
@@ -151,7 +151,7 @@ public class DeleteCommand extends Command {
 
         deleteAll(model, toDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_RANGE_SUCCESS,
-                toDelete.size(), range.get().getStart(), range.get().getEnd()));
+                toDelete.size(), range.get().getStart().get(), range.get().getEnd().get()));
     }
 
     private List<Person> getPersonsToDelete(List<Person> reference, Predicate<Person> predicate) {

--- a/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
@@ -95,8 +95,24 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         return indexBeforeDate | indexAfterDate;
     }
 
+    /**
+     * Tests whether the user has input an index after the date, which should be rejected.
+     * Returns true if there is an index after the date, false otherwise.
+     * @param date The argument to be tested.
+     * @return A boolean.
+     */
     private static boolean indexAfterDate(Optional<String> date) {
-        return !date.isEmpty() ? (date.get().trim().split("\\s+").length > 1) : false;
+        if (date.isEmpty()) {
+            return false;
+        }
+        String test = date.get();
+        int lastSpace = test.lastIndexOf(" ");
+        if (lastSpace == -1) {
+            return false;
+        } else {
+            String slicedDate = test.substring(0, lastSpace);
+            return Date.isValidDate(slicedDate) ? true : false;
+        }
     }
 
     /**

--- a/src/main/java/seedu/dengue/model/range/End.java
+++ b/src/main/java/seedu/dengue/model/range/End.java
@@ -7,4 +7,5 @@ import seedu.dengue.model.person.Person;
  */
 public interface End<T> {
     public boolean isAfter(Person p);
+    public T get();
 }

--- a/src/main/java/seedu/dengue/model/range/EndAge.java
+++ b/src/main/java/seedu/dengue/model/range/EndAge.java
@@ -48,4 +48,7 @@ public class EndAge implements End<Age> {
         int a2 = Integer.parseInt(start.age.get().value);
         return a1 >= a2;
     }
+    public Age get() {
+        return age.get();
+    }
 }

--- a/src/main/java/seedu/dengue/model/range/EndDate.java
+++ b/src/main/java/seedu/dengue/model/range/EndDate.java
@@ -49,4 +49,7 @@ public class EndDate implements End<Date> {
         LocalDate d2 = LocalDate.parse(start.date.get().value);
         return d1.compareTo(d2) >= 0;
     }
+    public Date get() {
+        return date.get();
+    }
 }

--- a/src/main/java/seedu/dengue/model/range/Start.java
+++ b/src/main/java/seedu/dengue/model/range/Start.java
@@ -7,4 +7,5 @@ import seedu.dengue.model.person.Person;
  */
 public interface Start<T> {
     public boolean isBefore(Person p);
+    public T get();
 }

--- a/src/main/java/seedu/dengue/model/range/StartAge.java
+++ b/src/main/java/seedu/dengue/model/range/StartAge.java
@@ -49,4 +49,7 @@ public class StartAge implements Start<Age> {
         int a2 = Integer.parseInt(end.age.get().value);
         return a1 <= a2;
     }
+    public Age get() {
+        return age.get();
+    }
 }

--- a/src/main/java/seedu/dengue/model/range/StartDate.java
+++ b/src/main/java/seedu/dengue/model/range/StartDate.java
@@ -49,4 +49,8 @@ public class StartDate implements Start<Date> {
         LocalDate d2 = LocalDate.parse(end.date.get().value);
         return d1.compareTo(d2) <= 0;
     }
+
+    public Date get() {
+        return date.get();
+    }
 }


### PR DESCRIPTION
Slices off the last part of the string. If it's still a valid date, last element was an index --> should be rejected

*This is a temporary fix for a separate bug in the Date formatter, which accepts dates like "23 mar 2023 4324334" despite the extra number "4324334" at the end. Ideally, that bug would be fixed, but this serves as a band-aid for now.