### PR TITLE
Clean code

### DIFF
--- a/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
@@ -111,7 +111,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return false;
         } else {
             String slicedDate = test.substring(0, lastSpace);
-            return Date.isValidDate(slicedDate) ? true : false;
+            return Date.isValidDate(slicedDate);
         }
     }
 


### PR DESCRIPTION
There was no need for a ternary operator since condition already returns a boolean... oops. One-line change!

Also attempted to delete my band-aid now that HY has merged his fix but for some reason a different bug will pop up without it..... leaving it in for now, if there's a way to simplify the parsing process in v1.4 would be ideal, but for now this covers the situation.