### PR TITLE
Improve defensiveness of range

### DIFF
--- a/src/main/java/seedu/dengue/model/person/ContinuousData.java
+++ b/src/main/java/seedu/dengue/model/person/ContinuousData.java
@@ -17,6 +17,6 @@ public interface ContinuousData {
      * @return A {@code Range<ContinuousData>}.
      */
     public static <R extends ContinuousData> Range<R> generateRange(Start<R> start, End<R> end) {
-        return new Range<R>(start, end);
+        return Range.<R>of(start, end);
     }
 }

--- a/src/main/java/seedu/dengue/model/range/Range.java
+++ b/src/main/java/seedu/dengue/model/range/Range.java
@@ -1,5 +1,7 @@
 package seedu.dengue.model.range;
 
+import seedu.dengue.model.person.ContinuousData;
+
 /**
  * Represents a range which can be used to signify age ranges, or date ranges to be used in predicates
  * to filter out people in the person list in the Dengue Hotspot Tracker.
@@ -15,9 +17,21 @@ public class Range<T> {
      * @param start A Start.
      * @param end An End.
      */
-    public Range(Start<T> start, End<T> end) {
+    private Range(Start<T> start, End<T> end) {
         this.start = start;
         this.end = end;
+    }
+
+    /**
+     * Constructs a {@code Range} of {@link ContinuousData} values.
+     * This ensures that only ranges of continuous data such as dates and ages can be created.
+     * @param start Start of the {@link ContinuousData} range.
+     * @param end End of the {@link ContinuousData} range.
+     * @param <R> An implementation of {@link ContinuousData} such as {@code Date}.
+     * @return A range.
+     */
+    public static <R extends ContinuousData> Range<R> of(Start<R> start, End<R> end) {
+        return new Range<>(start, end);
     }
 
     public Start<T> getStart() {


### PR DESCRIPTION
Previously, the Range constructor can be called anywhere in the code with any parameter T, such as Integer. However, we want Range to only consider dates and ages, in the form of continuous data. This PR will solve this problem.