### PR TITLE
Fix range

### DIFF
--- a/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/dengue/logic/parser/DeleteCommandParser.java
@@ -72,7 +72,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                         .getValue(PREFIX_STARTDATE)));
                 EndDate endDate = new EndDate(ParserUtil.parseOptionalDate(argMultimap
                         .getValue(PREFIX_ENDDATE)));
-                if (!startDate.isBefore(endDate)) {
+                if (!(startDate.isValidStartDate(endDate) && endDate.isValidEndDate(startDate))) {
                     throw new ParseException(MESSAGE_INVALID_RANGE);
                 }
                 Range<Date> range = ContinuousData.generateRange(startDate, endDate);

--- a/src/main/java/seedu/dengue/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/dengue/logic/parser/FindCommandParser.java
@@ -73,7 +73,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 .getValue(PREFIX_STARTDATE)));
         EndDate endDate = new EndDate(ParserUtil.parseOptionalDate(argumentMultimap
                 .getValue(PREFIX_ENDDATE)));
-        if (!startDate.isBefore(endDate)) {
+        if (!(startDate.isValidStartDate(endDate) && endDate.isValidEndDate(startDate))) {
             throw new ParseException(MESSAGE_INVALID_RANGE);
         }
         return ContinuousData.generateRange(startDate, endDate);
@@ -84,7 +84,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 .getValue(PREFIX_STARTAGE)));
         EndAge endAge = new EndAge(ParserUtil.parseOptionalAge(argumentMultimap
                 .getValue(PREFIX_ENDAGE)));
-        if (!startAge.isBefore(endAge)) {
+        if (!(startAge.isValidStartAge(endAge) && endAge.isValidEndAge(startAge))) {
             throw new ParseException(MESSAGE_INVALID_RANGE);
         }
         return ContinuousData.generateRange(startAge, endAge);

--- a/src/main/java/seedu/dengue/model/range/EndAge.java
+++ b/src/main/java/seedu/dengue/model/range/EndAge.java
@@ -40,14 +40,15 @@ public class EndAge implements End<Age> {
      *
      * @param start A StartAge.
      */
-    public boolean isAfter(StartAge start) {
-        if (!age.isPresent()) {
+    public boolean isValidEndAge(StartAge start) {
+        if (!(start.age.isPresent() && age.isPresent())) {
             return true;
         }
         int a1 = Integer.parseInt(age.get().value);
         int a2 = Integer.parseInt(start.age.get().value);
         return a1 >= a2;
     }
+
     public Age get() {
         return age.get();
     }

--- a/src/main/java/seedu/dengue/model/range/EndDate.java
+++ b/src/main/java/seedu/dengue/model/range/EndDate.java
@@ -41,14 +41,15 @@ public class EndDate implements End<Date> {
      *
      * @param start A StartDate.
      */
-    public boolean isAfter(StartDate start) {
-        if (!date.isPresent()) {
+    public boolean isValidEndDate(StartDate start) {
+        if (!(start.date.isPresent() && date.isPresent())) {
             return true;
         }
         LocalDate d1 = LocalDate.parse(date.get().value);
         LocalDate d2 = LocalDate.parse(start.date.get().value);
         return d1.compareTo(d2) >= 0;
     }
+
     public Date get() {
         return date.get();
     }

--- a/src/main/java/seedu/dengue/model/range/StartAge.java
+++ b/src/main/java/seedu/dengue/model/range/StartAge.java
@@ -41,14 +41,15 @@ public class StartAge implements Start<Age> {
      *
      * @param end An EndAge.
      */
-    public boolean isBefore(EndAge end) {
-        if (!age.isPresent()) {
+    public boolean isValidStartAge(EndAge end) {
+        if (!(end.age.isPresent() && age.isPresent())) {
             return true;
         }
         int a1 = Integer.parseInt(age.get().value);
         int a2 = Integer.parseInt(end.age.get().value);
         return a1 <= a2;
     }
+
     public Age get() {
         return age.get();
     }

--- a/src/main/java/seedu/dengue/model/range/StartDate.java
+++ b/src/main/java/seedu/dengue/model/range/StartDate.java
@@ -41,8 +41,8 @@ public class StartDate implements Start<Date> {
      *
      * @param end An EndDate.
      */
-    public boolean isBefore(EndDate end) {
-        if (!date.isPresent()) {
+    public boolean isValidStartDate(EndDate end) {
+        if (!(date.isPresent() && end.date.isPresent())) {
             return true;
         }
         LocalDate d1 = LocalDate.parse(date.get().value);


### PR DESCRIPTION
After numerous tests, it was found that the range functions were not working as intended. This was due to how the functions to check for validity of the ranges (such as whether the start date is after the end date or that the start age is after the end age vice versa) was not done properly within the range class. The overall issue lied with not checking for whether the optional contained a value or not in the user input start date or end date since they were optional to begin with.

Therefore, after finding out the problem, I have changed the following classes: EndAge, EndDate, StartAge, StartDate, DeleteCommandParser and FindCommandParser. Now the range works as per normal, however DeleteCommand may still have certain problems in parsing the optional values based on my testing. This bug will be solved by Valerie instead.